### PR TITLE
Fixed print keyword problem for Python 3.4 compatibility

### DIFF
--- a/autoscale.py
+++ b/autoscale.py
@@ -13,11 +13,11 @@ class MesosReporter():
     def __init__(self, mesos_url):
         self.mesos_url = mesos_url.rstrip('/')
         stats_url = '/'.join([self.mesos_url, '/stats.json'])
-        self.state = requests.get(stats_url).json()
+        self._state = requests.get(stats_url).json()
 
     @property
     def state(self):
-        return self.state
+        return self._state
 
 
 class MesosDecider():

--- a/autoscale.py
+++ b/autoscale.py
@@ -28,9 +28,9 @@ class MesosDecider():
         increment = 1
         decrement = -1
 
-        cpus_free = cluster.state['cpus_total'] - cluster.state['cpus_used']
-        disk_free = cluster.state['disk_total'] - cluster.state['disk_used']
-        mem_free = cluster.state['mem_total'] - cluster.state['mem_used']
+        cpus_free = cluster.state['master/cpus_total'] - cluster.state['master/cpus_used']
+        disk_free = cluster.state['master/disk_total'] - cluster.state['master/disk_used']
+        mem_free = cluster.state['master/mem_total'] - cluster.state['master/mem_used']
         logger.info('State: %s', dict(cpus_free=cpus_free, disk_free=disk_free, mem_free=mem_free))
         logger.info('Thresholds: %s', self.thresholds)
 

--- a/examples/mesos_ec2.py
+++ b/examples/mesos_ec2.py
@@ -38,10 +38,10 @@ def main():
     
     delta = decider.should_scale(reporter)
     if delta:
-        print 'Scaling {asg} in {region} by {delta}'.format(asg=args.asg, region=args.region, delta=delta)
+        print('Scaling {asg} in {region} by {delta}'.format(asg=args.asg, region=args.region, delta=delta))
         scaler.scale(delta)
     else:
-        print 'No change needed for {asg} in {region}'.format(asg=args.asg, region=args.region)
+        print('No change needed for {asg} in {region}'.format(asg=args.asg, region=args.region))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed to function syntax for print() instead of the removed keyword syntax
Avoid overwriting self.state descriptor
Account for changed Mesos JSON format
