### PR TITLE
Mesos: configurable endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3-onbuild
+MAINTAINER kpacha
+
+COPY ./examples/mesos_ec2.py mesos_ec2.py
+
+ENV MESOS_HOST=master.mesos
+ENV MESOS_PORT=5050
+ENV MESOS_ENDPOINT=/metrics/snapshot
+ENV MIN_CPUS=1
+ENV MAX_CPUS=3
+ENV MIN_MEM=512
+ENV MAX_MEM=10000
+ENV MIN_DISK=1000
+ENV MAX_DISK=100000
+ENV EC2_REGION=us-west-2
+ENV EC2_ASG="mesos-MesosSlaveStack-1AB12345ABC-ServerGroup-789XYZ789"
+ENV AUTOSCALER_LOG_LEVEL=info
+
+ENTRYPOINT [ "/bin/sh", "./run.sh" ]

--- a/autoscale.py
+++ b/autoscale.py
@@ -10,9 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class MesosReporter():
-    def __init__(self, mesos_url):
+    def __init__(self, mesos_url, mesos_endpoint):
         self.mesos_url = mesos_url.rstrip('/')
-        stats_url = '/'.join([self.mesos_url, '/stats.json'])
+        stats_url = '/'.join([self.mesos_url, mesos_endpoint])
+        logger.info('Stats url: %s', stats_url)
         self._state = requests.get(stats_url).json()
 
     @property

--- a/autoscale.py
+++ b/autoscale.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 class MesosReporter():
     def __init__(self, mesos_url, mesos_endpoint):
         self.mesos_url = mesos_url.rstrip('/')
-        stats_url = '/'.join([self.mesos_url, mesos_endpoint])
+        self.mesos_endpoint = mesos_endpoint.lstrip('/')
+        stats_url = '/'.join([self.mesos_url, self.mesos_endpoint])
         logger.info('Stats url: %s', stats_url)
         self._state = requests.get(stats_url).json()
 

--- a/examples/mesos_ec2.py
+++ b/examples/mesos_ec2.py
@@ -10,6 +10,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-l', '--log-level', default="warn", help='Log level (debug, [default] info, warn, error)')
     parser.add_argument('-u', '--mesos-url', help='Mesos cluster URL', required=True)
+    parser.add_argument('-e', '--mesos-endpoint', default="/master/snapshot", help='Mesos endpoint URL (/master/snapshot or /stats.json)')
     parser.add_argument('-c', '--cpus', help='Comma-delimited CPU thresholds (lower,upper)')    
     parser.add_argument('-d', '--disk', help='Comma-delimited disk thresholds (lower,upper)')
     parser.add_argument('-m', '--mem', help='Comma-delimited memory thresholds (lower,upper)')
@@ -32,7 +33,7 @@ def main():
         lower, upper = args.mem.split(',')
         thresholds['mem'] = dict(lower=int(lower), upper=int(upper))
 
-    reporter = MesosReporter(args.mesos_url)
+    reporter = MesosReporter(args.mesos_url, args.mesos_endpoint)
     decider = MesosDecider(thresholds)
     scaler = AwsAsgScaler(args.region, args.asg) 
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+autoscale

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python ./mesos_ec2.py -u "http://${MESOS_HOST}:${MESOS_PORT}" \
+    -c "${MIN_CPUS},${MAX_CPUS}" -r "${EC2_REGION}" \
+    -a "${EC2_ASG}" -l "${AUTOSCALER_LOG_LEVEL}" \
+    -e "${MESOS_ENDPOINT}" \
+    -d "${MIN_DISK},${MAX_DISK}" -m "${MIN_MEM},${MAX_MEM}"


### PR DESCRIPTION
The issue [MESOS-2058](https://issues.apache.org/jira/browse/MESOS-2058) has deprecated the `/stats.json` endpoint.

This PR changes the MesosReporter so its constructor accepts a second param. That param enables users to use the reporter with any mesos version.
